### PR TITLE
Update CoC link to PSF policies site

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 Please note that all interactions on
 [Python Software Foundation](https://www.python.org/psf-landing/)-supported
 infrastructure are [covered](https://www.python.org/psf/records/board/minutes/2014-01-06/#management-of-the-psfs-web-properties)
-by the [PSF Code of Conduct](https://www.python.org/psf/codeofconduct/),
+by the [PSF Code of Conduct](https://policies.python.org/python.org/code-of-conduct/),
 which includes all the infrastructure used in the development of Python itself
 (e.g. mailing lists, issue trackers, GitHub, etc.).
 


### PR DESCRIPTION
The PSF Code of Conduct is now at https://policies.python.org/python.org/code-of-conduct/

There's a redirect from the old page to the new one (https://github.com/python/pythondotorg/pull/2399) but let's link directly to its new home.