### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Please read the guidelines [on the
 official website](https://www.python.org/dev/security/) for
-instructions on how to report a security issues to
+instructions on how to report a security issue to
 the Python team responsibly.
 
 To reach the response team, email 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please read the guidelines [on the
+official website](https://www.python.org/dev/security/) for
+instructions on how to report a security issues to
+the Python team responsibly.
+
+To reach the response team, email 
+<a href="mailto:%73%65%63%75%72%69%74%79%40%70%79%74%68%6F%6E%2E%6F%72%67">security
+at python dot org</a>.


### PR DESCRIPTION
## What

- Sources a security policy so that users (hopefully) do not create issues on this repo

## Why

- There isn't one
- Clear communication for users to see how to report potential security issues

## See Also

https://github.com/python/pythondotorg/pull/2417